### PR TITLE
Baudrate settable in library constructor

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
 	name = "rot2prog",
-	version = "0.0.9",
+	version = "0.0.11",
 	author = "TJ Scherer",
 	author_email = "tjtractorboy@gmail.com",
 	description = "A python interface to the Alfa ROT2Prog Controller.",

--- a/src/rot2prog/rot2prog.py
+++ b/src/rot2prog/rot2prog.py
@@ -32,17 +32,18 @@ class ROT2Prog:
 
 	_limits_lock = Lock()
 
-	def __init__(self, port, timeout = 5):
+	def __init__(self, port, timeout = 5, baudrate = 600):
 		"""Creates object and opens serial connection.
 		
 		Args:
 		    port (str): Name of serial port to connect to.
+		    baudrate (int, optional): Communication speed. Defaults to 600.
 		    timeout (int, optional): Maximum response time from the controller.
 		"""
 		# open serial port
 		self._ser = serial.Serial(
 			port = port,
-			baudrate = 600,
+			baudrate = baudrate,
 			bytesize = 8,
 			parity = 'N',
 			stopbits = 1,


### PR DESCRIPTION
Made the baudrate settable through library constructor. 
This should not be a breaking change because the order of previous arguments has been kept. 

We need higher datarate than default to keep updates faster in order to minimize latency between real position and reported position.

Please make this into new release